### PR TITLE
fix number bug for company in sf0.01

### DIFF
--- a/tables/number-of-entities-transaction.tex
+++ b/tables/number-of-entities-transaction.tex
@@ -9,7 +9,7 @@
             \tableHeaderFirst{C} & \tableHeader{File} & \tableHeader{SF0.01} & \tableHeader{SF0.1} & \tableHeader{SF0.3} & \tableHeader{SF1}  & \tableHeader{SF3}  & \tableHeader{SF10}  \\ \hline
             \hline
             N                    & account            & \numprint{2633}      & \numprint{26347}    & \numprint{79199}    & \numprint{264075}  & \numprint{791769}  & \numprint{1980883}  \\
-            N                    & company            & \numprint{2633}      & \numprint{4000}     & \numprint{12000}    & \numprint{40000}   & \numprint{120000}  & \numprint{300000}   \\
+            N                    & company            & \numprint{400}      & \numprint{4000}     & \numprint{12000}    & \numprint{40000}   & \numprint{120000}  & \numprint{300000}   \\
             E                    & companyApplyLoan   & \numprint{524}       & \numprint{5332}     & \numprint{15761}    & \numprint{52820}   & \numprint{158678}  & \numprint{397060}   \\
             E                    & companyGuarantee   & \numprint{248}       & \numprint{2315}     & \numprint{7123}     & \numprint{23870}   & \numprint{71716}   & \numprint{179526}   \\
             E                    & companyInvest      & \numprint{860}       & \numprint{8639}     & \numprint{25853}    & \numprint{86092}   & \numprint{259884}  & \numprint{650190}   \\


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/12eada1b-374a-4931-9925-db97eab8111c)

the correct number should be 400.

```
Applied configuration from default of scale factor 0.01
 ... Num Persons 800
 ... Num Companies 400
 ... Start Year 2020
 ... Num Years 3
 ... Max degree of Powerlaw 1000
```